### PR TITLE
added sos link in header

### DIFF
--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -96,6 +96,16 @@ class Header extends Component {
                   About
                 </Link>
               </li>
+              <li>
+                <a
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  href="https://cyber-labs.github.io/sos"
+                  style={{color: "red"}}
+                >
+                  SOS
+                </a>
+              </li>
             </ul>
             <ul className="social-icon">
               <div className="social-index">


### PR DESCRIPTION
# Description
CyberLabs is conducting a month long open source event named [Season of Code](https://cyber-labs.github.io/sos/). So to increase the reach of the event we are planning to add the link of the event in the header which will redirect to the official website of Season of Code.

# Screenshot
![image](https://user-images.githubusercontent.com/54680709/198869638-53392aef-bb13-4ac0-a353-bb13e197b772.png)

# Note
The link will be removed from the header after the event ends.